### PR TITLE
Fix  Error retrieving SCMFileSystem 

### DIFF
--- a/src/main/java/au/com/versent/jenkins/plugins/ignoreCommitterStrategy/IgnoreCommitterStrategy.java
+++ b/src/main/java/au/com/versent/jenkins/plugins/ignoreCommitterStrategy/IgnoreCommitterStrategy.java
@@ -99,8 +99,7 @@ public class IgnoreCommitterStrategy extends BranchBuildStrategy {
 
             SCMFileSystem fileSystem;
             if (currRevision != null && !(currRevision instanceof AbstractGitSCMSource.SCMRevisionImpl)) {
-                fileSystem = builder.build(source, head, new AbstractGitSCMSource.SCMRevisionImpl(head,
-                        String.format("%40d", -currRevision.hashCode()).substring(0, 40).replaceAll(" ", "1")));
+                fileSystem = builder.build(source, head, new AbstractGitSCMSource.SCMRevisionImpl(head, currRevision.toString().substring(0,40)));
             } else {
                 fileSystem = builder.build(owner, scm, currRevision);
             }
@@ -113,8 +112,7 @@ public class IgnoreCommitterStrategy extends BranchBuildStrategy {
             ByteArrayOutputStream out = new ByteArrayOutputStream();
 
             if (prevRevision != null && !(prevRevision instanceof AbstractGitSCMSource.SCMRevisionImpl)) {
-                fileSystem.changesSince(new AbstractGitSCMSource.SCMRevisionImpl(head,
-                        String.format("%40d", -prevRevision.hashCode()).substring(0, 40).replaceAll(" ", "1")), out);
+                fileSystem.changesSince(new AbstractGitSCMSource.SCMRevisionImpl(head,prevRevision.toString().substring(0,40)), out);
             } else {
                 fileSystem.changesSince(prevRevision, out);
             }

--- a/src/main/java/au/com/versent/jenkins/plugins/ignoreCommitterStrategy/IgnoreCommitterStrategy.java
+++ b/src/main/java/au/com/versent/jenkins/plugins/ignoreCommitterStrategy/IgnoreCommitterStrategy.java
@@ -112,7 +112,7 @@ public class IgnoreCommitterStrategy extends BranchBuildStrategy {
 
             ByteArrayOutputStream out = new ByteArrayOutputStream();
 
-            if (currRevision != null && !(currRevision instanceof AbstractGitSCMSource.SCMRevisionImpl)) {
+            if (prevRevision != null && !(prevRevision instanceof AbstractGitSCMSource.SCMRevisionImpl)) {
                 fileSystem.changesSince(new AbstractGitSCMSource.SCMRevisionImpl(head,
                         String.format("%40d", -prevRevision.hashCode()).substring(0, 40).replaceAll(" ", "1")), out);
             } else {

--- a/src/main/java/au/com/versent/jenkins/plugins/ignoreCommitterStrategy/IgnoreCommitterStrategy.java
+++ b/src/main/java/au/com/versent/jenkins/plugins/ignoreCommitterStrategy/IgnoreCommitterStrategy.java
@@ -97,7 +97,7 @@ public class IgnoreCommitterStrategy extends BranchBuildStrategy {
                 return true;
             }
 
-            SCMFileSystem fileSystem = builder.build(owner, scm, currRevision);
+            SCMFileSystem fileSystem = builder.build(source, head, new AbstractGitSCMSource.SCMRevisionImpl(head,currRevision.toString()));
 
             if (fileSystem == null) {
                 LOGGER.log(Level.SEVERE, "Error retrieving SCMFileSystem");


### PR DESCRIPTION
ignoreCommitterStrategy gets error "Error retrieving SCMFileSystem " on github orgization jobs because currRevision is not instanceof AbstractGitSCMSource.SCMRevisionImpl. 

Check the type and convert to SCMRevisionImpl would fix it. 