### PR TITLE
Make title for email list textbox shorter

### DIFF
--- a/src/main/resources/au/com/versent/jenkins/plugins/ignoreCommitterStrategy/IgnoreCommitterStrategy/config.jelly
+++ b/src/main/resources/au/com/versent/jenkins/plugins/ignoreCommitterStrategy/IgnoreCommitterStrategy/config.jelly
@@ -1,6 +1,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <f:entry title="Don't trigger builds for pushes by certain Git commit author (comma-delimited list of author emails)" field="ignoredAuthors">
+  <f:entry title="List of author emails to ignore" field="ignoredAuthors">
     <f:textbox />
   </f:entry>
   <f:entry title="Allow builds when a changeset contains non-ignored author(s)" field="allowBuildIfNotExcludedAuthor">

--- a/src/main/resources/au/com/versent/jenkins/plugins/ignoreCommitterStrategy/IgnoreCommitterStrategy/help-ignoredAuthors.html
+++ b/src/main/resources/au/com/versent/jenkins/plugins/ignoreCommitterStrategy/IgnoreCommitterStrategy/help-ignoredAuthors.html
@@ -1,7 +1,7 @@
 <div>
     <p>
-        A comma-delimited list of Git commit author emails to ignore builds from. The obvious use-case for this is
-        ignoring  by a designated Jenkins git user, so that your builds don't trigger
+        A comma-delimited list of Git commit author emails to ignore builds from. One common use-case for this is
+        ignoring commits by a designated Jenkins git user, so that your builds don't trigger
         more builds.
     </p>
     <p>


### PR DESCRIPTION
Currently the title for the `ignoredAuthors` textbox is very long, which makes the textbox very small and not usable (see screenshot)

<img width="1070" alt="screen shot 2018-11-27 at 1 53 43 pm" src="https://user-images.githubusercontent.com/1652595/49104754-c5840500-f24c-11e8-8414-9a3656272dbb.png">

This makes the title short and concise, and rely on the help text for more explanation and context.

/cc @b-b3rn4rd