### PR TITLE
Added support for subversion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,9 +44,10 @@
     <url>https://github.com/jenkinsci/jenkins-${project.artifactId}-plugin</url>
 
     <properties>
-        <jenkins.version>2.86</jenkins.version>
-        <scm-api.version>2.2.6</scm-api.version>
+        <jenkins.version>2.107.3</jenkins.version>
+        <scm-api.version>2.6.3</scm-api.version>
         <git-plugin.version>3.6.0</git-plugin.version>
+        <svn-plugin.version>2.12.2</svn-plugin.version>
         <java.level>8</java.level>
     </properties>
 
@@ -116,6 +117,11 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>git</artifactId>
             <version>${git-plugin.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>subversion</artifactId>
+            <version>${svn-plugin.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/au/com/versent/jenkins/plugins/ignoreCommitterStrategy/IgnoreCommitterStrategy.java
+++ b/src/main/java/au/com/versent/jenkins/plugins/ignoreCommitterStrategy/IgnoreCommitterStrategy.java
@@ -25,16 +25,29 @@ package au.com.versent.jenkins.plugins.ignoreCommitterStrategy;
 
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.Job;
+import hudson.model.TaskListener;
+import hudson.model.User;
+import hudson.scm.ChangeLogParser;
 import hudson.scm.SCM;
+import hudson.scm.SubversionChangeLogParser;
+import hudson.scm.SubversionChangeLogSet;
 import jenkins.model.Jenkins;
 import jenkins.plugins.git.AbstractGitSCMSource;
 import jenkins.scm.api.*;
+import jenkins.scm.impl.subversion.SubversionSCMFileSystem;
+import jenkins.scm.impl.subversion.SubversionSCMSource;
 import org.kohsuke.stapler.DataBoundConstructor;
 import jenkins.branch.BranchBuildStrategy;
 import jenkins.branch.BranchBuildStrategyDescriptor;
 
+import java.io.File;
+import java.lang.reflect.Method;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
 
@@ -45,6 +58,12 @@ import java.io.ByteArrayInputStream;
 
 import hudson.plugins.git.GitChangeLogParser;
 import hudson.plugins.git.GitChangeSet;
+import org.tmatesoft.svn.core.ISVNLogEntryHandler;
+import org.tmatesoft.svn.core.SVNException;
+import org.tmatesoft.svn.core.SVNLogEntry;
+import org.tmatesoft.svn.core.io.SVNRepository;
+import org.tmatesoft.svn.core.wc.SVNRevision;
+
 import java.util.logging.Level;
 
 import java.util.Arrays;
@@ -86,7 +105,12 @@ public class IgnoreCommitterStrategy extends BranchBuildStrategy {
      */
     @Override
     public boolean isAutomaticBuild(SCMSource source, SCMHead head, SCMRevision currRevision, SCMRevision prevRevision) {
-        GitSCMFileSystem.Builder builder = new GitSCMFileSystem.BuilderImpl();
+        boolean isSVN = false;
+
+        SubversionSCMFileSystem.Builder svnBuilder = new SubversionSCMFileSystem.BuilderImpl();
+        if (svnBuilder.supports(source)) {
+            isSVN = true;
+        }
 
         try {
             SCM scm = source.build(head, currRevision);
@@ -98,10 +122,15 @@ public class IgnoreCommitterStrategy extends BranchBuildStrategy {
             }
 
             SCMFileSystem fileSystem;
-            if (currRevision != null && !(currRevision instanceof AbstractGitSCMSource.SCMRevisionImpl)) {
-                fileSystem = builder.build(source, head, new AbstractGitSCMSource.SCMRevisionImpl(head, currRevision.toString().substring(0,40)));
+            if (!isSVN) {
+                GitSCMFileSystem.Builder gitBuilder = new GitSCMFileSystem.BuilderImpl();
+                if (currRevision != null && !(currRevision instanceof AbstractGitSCMSource.SCMRevisionImpl)) {
+                    fileSystem = gitBuilder.build(source, head, new AbstractGitSCMSource.SCMRevisionImpl(head, currRevision.toString().substring(0, 40)));
+                } else {
+                    fileSystem = gitBuilder.build(owner, scm, currRevision);
+                }
             } else {
-                fileSystem = builder.build(owner, scm, currRevision);
+                fileSystem = svnBuilder.build(source, head, currRevision);
             }
 
             if (fileSystem == null) {
@@ -109,45 +138,92 @@ public class IgnoreCommitterStrategy extends BranchBuildStrategy {
                 return true;
             }
 
-            ByteArrayOutputStream out = new ByteArrayOutputStream();
-
-            if (prevRevision != null && !(prevRevision instanceof AbstractGitSCMSource.SCMRevisionImpl)) {
-                fileSystem.changesSince(new AbstractGitSCMSource.SCMRevisionImpl(head,prevRevision.toString().substring(0,40)), out);
-            } else {
-                fileSystem.changesSince(prevRevision, out);
-            }
-
-            GitChangeLogParser parser = new GitChangeLogParser(true);
-
-            List<GitChangeSet> logs = parser.parse(new ByteArrayInputStream(out.toByteArray()));
             List<String> ignoredAuthorsList = Arrays.stream(
                     ignoredAuthors.split(",")).map(e -> e.trim().toLowerCase()).collect(Collectors.toList());
-
-            LOGGER.info(String.format("Ignored authors: %s", ignoredAuthorsList.toString()));
-
-            for (GitChangeSet log : logs) {
-                String authorEmail = log.getAuthorEmail().trim().toLowerCase();
-                Boolean isIgnoredAuthor = ignoredAuthorsList.contains(authorEmail);
-
-                if (isIgnoredAuthor) {
-                    if (!allowBuildIfNotExcludedAuthor) {
-                        // if author is ignored and changesets with at least one non-excluded author are not allowed
-                        LOGGER.info(String.format(
-                                "Changeset contains ignored author %s (%s), and allowBuildIfNotExcludedAuthor is %s, therefore build is not required",
-                                authorEmail, log.getCommitId(), allowBuildIfNotExcludedAuthor));
-                        return false;
-                    }
-
+            if (!isSVN) {
+                ByteArrayOutputStream out = new ByteArrayOutputStream();
+                if (prevRevision != null && !(prevRevision instanceof AbstractGitSCMSource.SCMRevisionImpl)) {
+                    fileSystem.changesSince(new AbstractGitSCMSource.SCMRevisionImpl(head, prevRevision.toString().substring(0, 40)), out);
                 } else {
-                    if (allowBuildIfNotExcludedAuthor) {
-                        // if author is not ignored and changesets with at least one non-excluded author are allowed
-                        LOGGER.info(String.format(
-                                "Changeset contains non ignored author %s (%s) and allowIfNotExcluded is %s, build is required",
-                                authorEmail, log.getCommitId(), allowBuildIfNotExcludedAuthor));
-                        return true;
+                    fileSystem.changesSince(prevRevision, out);
+                }
+                GitChangeLogParser parser = new GitChangeLogParser(true);
+                List<GitChangeSet> logs = parser.parse(new ByteArrayInputStream(out.toByteArray()));
+
+                LOGGER.info(String.format("Ignored authors: %s", ignoredAuthorsList.toString()));
+
+                for (GitChangeSet log : logs) {
+                    String authorEmail = log.getAuthorEmail().trim().toLowerCase();
+                    Boolean isIgnoredAuthor = ignoredAuthorsList.contains(authorEmail);
+
+                    if (isIgnoredAuthor) {
+                        if (!allowBuildIfNotExcludedAuthor) {
+                            // if author is ignored and changesets with at least one non-excluded author are not allowed
+                            LOGGER.info(String.format(
+                                    "Changeset contains ignored author %s (%s), and allowBuildIfNotExcludedAuthor is %s, therefore build is not required",
+                                    authorEmail, log.getCommitId(), allowBuildIfNotExcludedAuthor));
+                            return false;
+                        }
+
+                    } else {
+                        if (allowBuildIfNotExcludedAuthor) {
+                            // if author is not ignored and changesets with at least one non-excluded author are allowed
+                            LOGGER.info(String.format(
+                                    "Changeset contains non ignored author %s (%s) and allowIfNotExcluded is %s, build is required",
+                                    authorEmail, log.getCommitId(), allowBuildIfNotExcludedAuthor));
+                            return true;
+                        }
+                    }
+                }
+            } else {
+                Method getRepository = fileSystem.getClass().getDeclaredMethod("getRepository");
+                AccessController.doPrivileged(new PrivilegedAction() {
+                    public Object run() {
+                        getRepository.setAccessible(true);
+                        return null; // nothing to return
+                    }
+                });
+                SVNRepository svnRepository = (SVNRepository)getRepository.invoke(fileSystem);
+
+                int start, end;
+                end = Integer.parseInt(currRevision.toString());
+                start = Integer.parseInt(prevRevision.toString())+1;
+
+                ArrayList<SVNLogEntry> entries = new ArrayList<>();
+                String[] paths = {"."};
+                svnRepository.log(paths, start, end, false, false, new ISVNLogEntryHandler() {
+                    @Override
+                    public void handleLogEntry(SVNLogEntry svnLogEntry) throws SVNException {
+                        entries.add(svnLogEntry);
+                    }
+                });
+
+                for (SVNLogEntry entry: entries) {
+                    String authorId = entry.getAuthor().trim().toLowerCase();
+                    Boolean isIgnoredAuthor = ignoredAuthorsList.contains(authorId);
+
+                    if (isIgnoredAuthor) {
+                        if (!allowBuildIfNotExcludedAuthor) {
+                            // if author is ignored and changesets with at least one non-excluded author are not allowed
+                            LOGGER.info(String.format(
+                                    "Changeset contains ignored author %s (%s), and allowBuildIfNotExcludedAuthor is %s, therefore build is not required",
+                                    authorId, entry.getRevision(), allowBuildIfNotExcludedAuthor));
+                            return false;
+                        }
+
+                    } else {
+                        if (allowBuildIfNotExcludedAuthor) {
+                            // if author is not ignored and changesets with at least one non-excluded author are allowed
+                            LOGGER.info(String.format(
+                                    "Changeset contains non ignored author %s (%s) and allowIfNotExcluded is %s, build is required",
+                                    authorId, entry.getRevision(), allowBuildIfNotExcludedAuthor));
+                            return true;
+                        }
                     }
                 }
             }
+
+
             // here if commits are made by ignored authors and allowBuildIfNotExcludedAuthor is true, in this case return false
             // or if all commits are made by non-ignored authors and allowBuildIfNotExcludedAuthor is false, in this case return true
             LOGGER.info(String.format("All commits in the changeset are made by %s excluded authors, build is %s",


### PR DESCRIPTION
To this plugin, added dependency to the plugin org.jenkins-ci.plugins:subversion
If the repository being scanned is subversion, use svn API to check if the
revisitions match.

One problematic part, I had to use reflection to get the SVNRepository
interface from the SCMFileSystem. Having got this, could call the log()
method to get the commits.

The required methods seem to be private
and/or not implemented. For instance, it seemed like the SCMFileSystem::
changesSince() method would be useful to use, but it is not implemented
for the SubversionSCMFileSystem class.