### PR TITLE
Require Jenkins 2.452.4 or newer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ hs_err_pid*
 .idea
 .DS_Store
 *.iml
+/nbproject/

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>io.jenkins.tools.incrementals</groupId>
+    <artifactId>git-changelist-maven-extension</artifactId>
+    <version>1.8</version>
+  </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Pconsume-incrementals
+-Pmight-produce-incrementals

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,10 @@
-buildPlugin()
+/*
+ See the documentation for more options:
+ https://github.com/jenkins-infra/pipeline-library/
+*/
+buildPlugin(
+  useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
+  configurations: [
+    [platform: 'linux', jdk: 21],
+    [platform: 'windows', jdk: 17],
+])

--- a/README.md
+++ b/README.md
@@ -1,27 +1,27 @@
-Jenkins Ignore Committer Strategy Plugin
-==========================================
-This plugin provides addition configuration to prevent multi branch projects from triggering new builds based on a list of ignored email addresses.
+# Ignore Committer Strategy Plugin
 
-Installation & Configuration
-============================
-The easiest way to install this plugin is through the plugin manager. 
-Go to `Manage Jenkins > Manage Plugins > Available` and search for `Ignore committer strategy`
+This plugin provides additional configuration to prevent multi-branch projects from triggering new builds based on a list of ignored email addresses.
+
+## Configuration
+
 Once the plugin is installed, go to your job's configuration page
 and under `Branch Sources` use the *Add* button next to `Build Strategies` and add `Ignore committer strategy`.
-![Alt text](./plugin-add.png?raw=true "Adding build strategy")
+
+![Adding build strategy](./plugin-add.png?raw=true "Adding build strategy")
 
 The default behaviour is to prevent triggering new builds if at least one of the authors in the changeset
 is specified in the ignore list. However, it can be changed by ticking `	Allow builds when a changeset contains non-ignored author(s)`
 checkbox, in this case a new build will be triggered if changeset contains an author that is not in the exclusion list.
-![Alt text](./plugin-config.png?raw=true "Configuring build strategy")
 
-Local interactive testing
-====================
+![Configuring build strategy](./plugin-config.png?raw=true "Configuring build strategy")
+
+## Local interactive testing
+
 In order to run this plugin locally run the following command
 ```bash
 mvn hpi:run
 ```
 
-Debugging
-================
+## Debugging
+
 The plugin logs are available under `Manage Jenkins > System Log > All Jenkins Logs`, optionally, you can add your own log recorded to catch only plugin specific messages.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Jenkins Ignore Committer Strategy Plugin
 ==========================================
-This plugin provides addition configuration to prevent multi branch projects from triggering new builds based on a blacklist of users.
+This plugin provides addition configuration to prevent multi branch projects from triggering new builds based on a list of ignored email addresses.
 
 Installation & Configuration
 ============================

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 
     <groupId>au.com.versent.jenkins.plugins</groupId>
     <artifactId>ignore-committer-strategy</artifactId>
-    <version>1.0.4</version>
+    <version>1.0.5-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>Ignore Committer Strategy</name>
     <description>This plugin provides additional configuration to prevent multi branch projects from triggering new builds
@@ -68,7 +68,7 @@
         <developerConnection>scm:git:git@github.com:jenkinsci/jenkins-${project.artifactId}-plugin.git
         </developerConnection>
         <url>https://github.com/jenkinsci/jenkins-${project.artifactId}-plugin</url>
-      <tag>ignore-committer-strategy-1.0.4</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>3532.v8059503f6b_23</version>
+        <version>3559.vb_5b_81183b_d23</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -36,12 +36,15 @@
 
     <groupId>au.com.versent.jenkins.plugins</groupId>
     <artifactId>ignore-committer-strategy</artifactId>
-    <version>1.0.5-SNAPSHOT</version>
+    <version>${revision}${changelist}</version>
     <packaging>hpi</packaging>
     <name>Ignore Committer Strategy</name>
     <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
 
     <properties>
+        <revision>1.0.5</revision>
+        <changelist>-SNAPSHOT</changelist>
+        <gitHubRepo>jenkinsci/ignore-committer-strategy-plugin</gitHubRepo>
         <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
         <jenkins.baseline>2.452</jenkins.baseline>
         <jenkins.version>${jenkins.baseline}.4</jenkins.version>
@@ -61,11 +64,10 @@
         </developer>
     </developers>
     <scm>
-        <connection>scm:git:https://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
-        <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git
-        </developerConnection>
-        <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-      <tag>HEAD</tag>
+        <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
+        <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+        <url>https://github.com/${gitHubRepo}</url>
+      <tag>${scmTag}</tag>
   </scm>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.53</version>
+        <version>4.88</version>
         <relativePath />
     </parent>
 
@@ -44,10 +44,9 @@
     <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
 
     <properties>
-        <jenkins.version>2.86</jenkins.version>
-        <scm-api.version>2.2.6</scm-api.version>
-        <git-plugin.version>3.6.0</git-plugin.version>
-        <java.level>8</java.level>
+        <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
+        <jenkins.baseline>2.452</jenkins.baseline>
+        <jenkins.version>${jenkins.baseline}.4</jenkins.version>
     </properties>
 
 
@@ -64,7 +63,7 @@
         </developer>
     </developers>
     <scm>
-        <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
+        <connection>scm:git:https://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git
         </developerConnection>
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
@@ -85,131 +84,67 @@
         </pluginRepository>
     </pluginRepositories>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-${jenkins.baseline}.x</artifactId>
+                <version>3532.v8059503f6b_23</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
-        <dependency>
-            <groupId>org.kohsuke</groupId>
-            <artifactId>access-modifier-annotation</artifactId>
-            <version>1.11</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci</groupId>
-            <artifactId>annotation-indexer</artifactId>
-            <version>1.12</version>
-        </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>junit</artifactId>
-            <version>1.3</version>
         </dependency>
-        <!-- plugin dependencies -->
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>scm-api</artifactId>
-            <version>${scm-api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>scm-api</artifactId>
+            <classifier>tests</classifier>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>github-api</artifactId>
-            <version>1.90</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>git</artifactId>
-            <version>${git-plugin.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>git</artifactId>
+            <classifier>tests</classifier>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>branch-api</artifactId>
-            <version>2.0.17</version>
-        </dependency>
-        <!-- /plugin dependencies -->
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-core</artifactId>
-            <version>2.1</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <!-- For interactive testing via hpi:run -->
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-job</artifactId>
-            <version>2.16</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-step-api</artifactId>
-            <version>2.14</version>
-            <scope>test</scope>
+            <artifactId>workflow-multibranch</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>token-macro</artifactId>
-            <version>2.3</version>
-            <scope>test</scope>
+            <artifactId>git-client</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.jenkins.test.fips</groupId>
+                    <artifactId>fips-bundle-test</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>plain-credentials</artifactId>
-            <version>1.4</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>script-security</artifactId>
-            <version>1.39</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>credentials</artifactId>
-            <version>2.1.16</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>structs</artifactId>
-            <version>1.10</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-scm-step</artifactId>
-            <version>2.6</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-aggregator</artifactId>
-            <version>2.5</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>github-branch-source</artifactId>
-            <version>2.3.2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>cloudbees-bitbucket-branch-source</artifactId>
-            <version>1.4</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>3.7</version>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -92,12 +92,6 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git-client</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>io.jenkins.test.fips</groupId>
-          <artifactId>fips-bundle-test</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <name>Ignore Committer Strategy</name>
     <description>This plugin provides additional configuration to prevent multi branch projects from triggering new builds
         based on a blacklist of commit authors.</description>
-    <url>https://github.com/jenkinsci/jenkins-${project.artifactId}-plugin</url>
+    <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
 
     <properties>
         <jenkins.version>2.86</jenkins.version>
@@ -64,10 +64,10 @@
         </developer>
     </developers>
     <scm>
-        <connection>scm:git:git://github.com/jenkinsci/jenkins-${project.artifactId}-plugin.git</connection>
-        <developerConnection>scm:git:git@github.com:jenkinsci/jenkins-${project.artifactId}-plugin.git
+        <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
+        <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git
         </developerConnection>
-        <url>https://github.com/jenkinsci/jenkins-${project.artifactId}-plugin</url>
+        <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
       <tag>HEAD</tag>
   </scm>
 

--- a/pom.xml
+++ b/pom.xml
@@ -39,8 +39,6 @@
     <version>1.0.5-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>Ignore Committer Strategy</name>
-    <description>This plugin provides additional configuration to prevent multi branch projects from triggering new builds
-        based on a list of email addresses of commit authors.</description>
     <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <packaging>hpi</packaging>
     <name>Ignore Committer Strategy</name>
     <description>This plugin provides additional configuration to prevent multi branch projects from triggering new builds
-        based on a blacklist of commit authors.</description>
+        based on a list of email addresses of commit authors.</description>
     <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -23,129 +23,128 @@
 ~ THE SOFTWARE.
 ~
 -->
-
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+  <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>plugin</artifactId>
-        <version>4.88</version>
-        <relativePath />
-    </parent>
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>4.88</version>
+    <relativePath />
+  </parent>
 
-    <groupId>au.com.versent.jenkins.plugins</groupId>
-    <artifactId>ignore-committer-strategy</artifactId>
-    <version>${revision}${changelist}</version>
-    <packaging>hpi</packaging>
-    <name>Ignore Committer Strategy</name>
-    <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
+  <groupId>au.com.versent.jenkins.plugins</groupId>
+  <artifactId>ignore-committer-strategy</artifactId>
+  <version>${revision}${changelist}</version>
+  <packaging>hpi</packaging>
+  <name>Ignore Committer Strategy</name>
+  <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
 
-    <properties>
-        <revision>1.0.5</revision>
-        <changelist>-SNAPSHOT</changelist>
-        <gitHubRepo>jenkinsci/ignore-committer-strategy-plugin</gitHubRepo>
-        <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-        <jenkins.baseline>2.452</jenkins.baseline>
-        <jenkins.version>${jenkins.baseline}.4</jenkins.version>
-    </properties>
-
-
-    <licenses>
-        <license>
-            <name>MIT License</name>
-            <url>http://opensource.org/licenses/MIT</url>
-        </license>
-    </licenses>
-    <developers>
-        <developer>
-            <id>bb3rn4rd</id>
-            <name>Bernard Baltrusaitis</name>
-        </developer>
-    </developers>
-    <scm>
-        <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
-        <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
-        <url>https://github.com/${gitHubRepo}</url>
-      <tag>${scmTag}</tag>
+  <licenses>
+    <license>
+      <name>MIT License</name>
+      <url>http://opensource.org/licenses/MIT</url>
+    </license>
+  </licenses>
+  <developers>
+    <developer>
+      <id>bb3rn4rd</id>
+      <name>Bernard Baltrusaitis</name>
+    </developer>
+  </developers>
+  <scm>
+    <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
+    <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+    <tag>${scmTag}</tag>
+    <url>https://github.com/${gitHubRepo}</url>
   </scm>
 
-    <repositories>
-        <repository>
-            <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/public/</url>
-        </repository>
-    </repositories>
+  <properties>
+    <revision>1.0.5</revision>
+    <changelist>-SNAPSHOT</changelist>
+    <gitHubRepo>jenkinsci/ignore-committer-strategy-plugin</gitHubRepo>
+    <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
+    <jenkins.baseline>2.452</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.4</jenkins.version>
+    <spotless.check.skip>false</spotless.check.skip>
+  </properties>
 
-    <pluginRepositories>
-        <pluginRepository>
-            <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/public/</url>
-        </pluginRepository>
-    </pluginRepositories>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-${jenkins.baseline}.x</artifactId>
-                <version>3532.v8059503f6b_23</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
+  <dependencyManagement>
     <dependencies>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>junit</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>scm-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>scm-api</artifactId>
-            <classifier>tests</classifier>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>github-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>git</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>git</artifactId>
-            <classifier>tests</classifier>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>branch-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-multibranch</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>git-client</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>io.jenkins.test.fips</groupId>
-                    <artifactId>fips-bundle-test</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <scope>test</scope>
-        </dependency>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-${jenkins.baseline}.x</artifactId>
+        <version>3532.v8059503f6b_23</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
     </dependencies>
+  </dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>branch-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>git</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>git-client</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>io.jenkins.test.fips</groupId>
+          <artifactId>fips-bundle-test</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>github-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>scm-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-multibranch</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>git</artifactId>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>scm-api</artifactId>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>subversion</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/src/main/java/au/com/versent/jenkins/plugins/ignoreCommitterStrategy/IgnoreCommitterStrategy.java
+++ b/src/main/java/au/com/versent/jenkins/plugins/ignoreCommitterStrategy/IgnoreCommitterStrategy.java
@@ -97,7 +97,7 @@ public class IgnoreCommitterStrategy extends BranchBuildStrategy {
             }
 
             SCMFileSystem fileSystem;
-            if (currRevision != null && !(currRevision instanceof AbstractGitSCMSource.SCMRevisionImpl)) {
+            if (!(currRevision instanceof AbstractGitSCMSource.SCMRevisionImpl)) {
                 fileSystem = builder.build(
                         source,
                         head,
@@ -163,8 +163,8 @@ public class IgnoreCommitterStrategy extends BranchBuildStrategy {
             // case return true
             listener.getLogger()
                     .printf(
-                            "All commits in the changeset are made by %s excluded authors, build is %s%n",
-                            allowBuildIfNotExcludedAuthor ? "" : "Non", !allowBuildIfNotExcludedAuthor);
+                            "All commits in the changeset are made by %sexcluded authors, build is %s%n",
+                            allowBuildIfNotExcludedAuthor ? "" : "non-", !allowBuildIfNotExcludedAuthor);
 
             return !allowBuildIfNotExcludedAuthor;
         } catch (Exception e) {

--- a/src/main/java/au/com/versent/jenkins/plugins/ignoreCommitterStrategy/IgnoreCommitterStrategy.java
+++ b/src/main/java/au/com/versent/jenkins/plugins/ignoreCommitterStrategy/IgnoreCommitterStrategy.java
@@ -24,11 +24,9 @@
 package au.com.versent.jenkins.plugins.ignoreCommitterStrategy;
 
 
-import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.Extension;
-import hudson.model.Job;
+import hudson.model.TaskListener;
 import hudson.scm.SCM;
-import jenkins.model.Jenkins;
 import jenkins.plugins.git.AbstractGitSCMSource;
 import jenkins.scm.api.*;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -85,7 +83,7 @@ public class IgnoreCommitterStrategy extends BranchBuildStrategy {
      * @return true if changeset does not have commits by ignored users or at least one user is not excluded and {allowBuildIfNotExcludedAuthor} is true
      */
     @Override
-    public boolean isAutomaticBuild(SCMSource source, SCMHead head, SCMRevision currRevision, SCMRevision prevRevision) {
+    public boolean isAutomaticBuild(SCMSource source, SCMHead head, SCMRevision currRevision, SCMRevision prevRevision, SCMRevision lastSeenRevision, TaskListener listener) {
         GitSCMFileSystem.Builder builder = new GitSCMFileSystem.BuilderImpl();
 
         try {

--- a/src/main/java/au/com/versent/jenkins/plugins/ignoreCommitterStrategy/IgnoreCommitterStrategy.java
+++ b/src/main/java/au/com/versent/jenkins/plugins/ignoreCommitterStrategy/IgnoreCommitterStrategy.java
@@ -163,8 +163,9 @@ public class IgnoreCommitterStrategy extends BranchBuildStrategy {
             // case return true
             listener.getLogger()
                     .printf(
-                            "All commits in the changeset are made by %sexcluded authors, build is %s%n",
-                            allowBuildIfNotExcludedAuthor ? "" : "non-", !allowBuildIfNotExcludedAuthor);
+                            "All commits in the changeset are made by %s authors, build is %s%n",
+                            allowBuildIfNotExcludedAuthor ? "excluded" : "non-excluded",
+                            !allowBuildIfNotExcludedAuthor);
 
             return !allowBuildIfNotExcludedAuthor;
         } catch (Exception e) {

--- a/src/main/java/au/com/versent/jenkins/plugins/ignoreCommitterStrategy/IgnoreCommitterStrategy.java
+++ b/src/main/java/au/com/versent/jenkins/plugins/ignoreCommitterStrategy/IgnoreCommitterStrategy.java
@@ -83,7 +83,7 @@ public class IgnoreCommitterStrategy extends BranchBuildStrategy {
      * @return true if changeset does not have commits by ignored users or at least one user is not excluded and {allowBuildIfNotExcludedAuthor} is true
      */
     @Override
-    public boolean isAutomaticBuild(SCMSource source, SCMHead head, SCMRevision currRevision, SCMRevision prevRevision, SCMRevision lastSeenRevision, TaskListener listener) {
+    public boolean isAutomaticBuild(SCMSource source, SCMHead head, SCMRevision currRevision, SCMRevision lastBuiltRevision, SCMRevision lastSeenRevision, TaskListener listener) {
         GitSCMFileSystem.Builder builder = new GitSCMFileSystem.BuilderImpl();
 
         try {
@@ -109,10 +109,10 @@ public class IgnoreCommitterStrategy extends BranchBuildStrategy {
 
             ByteArrayOutputStream out = new ByteArrayOutputStream();
 
-            if (prevRevision != null && !(prevRevision instanceof AbstractGitSCMSource.SCMRevisionImpl)) {
-                fileSystem.changesSince(new AbstractGitSCMSource.SCMRevisionImpl(head,prevRevision.toString().substring(0,40)), out);
+            if (lastBuiltRevision != null && !(lastBuiltRevision instanceof AbstractGitSCMSource.SCMRevisionImpl)) {
+                fileSystem.changesSince(new AbstractGitSCMSource.SCMRevisionImpl(head,lastBuiltRevision.toString().substring(0,40)), out);
             } else {
-                fileSystem.changesSince(prevRevision, out);
+                fileSystem.changesSince(lastBuiltRevision, out);
             }
 
             GitChangeLogParser parser = new GitChangeLogParser(true);

--- a/src/main/resources/au/com/versent/jenkins/plugins/ignoreCommitterStrategy/IgnoreCommitterStrategy/help-allowBuildIfNotExcludedAuthor.html
+++ b/src/main/resources/au/com/versent/jenkins/plugins/ignoreCommitterStrategy/IgnoreCommitterStrategy/help-allowBuildIfNotExcludedAuthor.html
@@ -1,6 +1,6 @@
 <div>
     <p>
         If checked, build will be triggered when at least one of the committers in changeset is not in the exemption list.
-        <i>if un-ticked build won't be triggered if changeset contains commit(s) from a blacklisted user</i>i>
+        <i>If unchecked, build won't be triggered if changeset contains commit(s) from an ignored user.</i>
     </p>
 </div>

--- a/src/main/resources/au/com/versent/jenkins/plugins/ignoreCommitterStrategy/IgnoreCommitterStrategy/help-ignoredAuthors.html
+++ b/src/main/resources/au/com/versent/jenkins/plugins/ignoreCommitterStrategy/IgnoreCommitterStrategy/help-ignoredAuthors.html
@@ -1,6 +1,7 @@
 <div>
     <p>
-        A comma-delimited list of Git commit author emails to ignore builds from. One common use-case for this is
+        A comma-delimited list of Git commit author emails whose commits should not trigger a build.
+	One common use-case for this is
         ignoring commits by a designated Jenkins git user, so that your builds don't trigger
         more builds.
     </p>

--- a/src/main/resources/au/com/versent/jenkins/plugins/ignoreCommitterStrategy/IgnoreCommitterStrategy/help-ignoredAuthors.html
+++ b/src/main/resources/au/com/versent/jenkins/plugins/ignoreCommitterStrategy/IgnoreCommitterStrategy/help-ignoredAuthors.html
@@ -1,7 +1,7 @@
 <div>
     <p>
         A comma-delimited list of Git commit author emails whose commits should not trigger a build.
-	One common use-case for this is
+        One common use-case for this is
         ignoring commits by a designated Jenkins git user, so that your builds don't trigger
         more builds.
     </p>

--- a/src/main/resources/au/com/versent/jenkins/plugins/ignoreCommitterStrategy/IgnoreCommitterStrategy/help.html
+++ b/src/main/resources/au/com/versent/jenkins/plugins/ignoreCommitterStrategy/IgnoreCommitterStrategy/help.html
@@ -1,0 +1,3 @@
+<div>
+    Provides additional configuration to prevent multi-branch projects from triggering new builds based on a list of ignored email addresses.
+</div>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -25,5 +25,5 @@
 -->
 <div>
   This plugin provides addition configuration to prevent multi branch projects from triggering new builds
-  based on a blacklist of users.
+  based on a list of ignored email addresses.
 </div>

--- a/src/test/java/au/com/versent/jenkins/plugins/ignoreCommitterStrategy/IgnoreCommitterStrategySimpleTest.java
+++ b/src/test/java/au/com/versent/jenkins/plugins/ignoreCommitterStrategy/IgnoreCommitterStrategySimpleTest.java
@@ -25,6 +25,7 @@ package au.com.versent.jenkins.plugins.ignoreCommitterStrategy;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+
 import org.junit.jupiter.api.Test;
 
 public class IgnoreCommitterStrategySimpleTest {

--- a/src/test/java/au/com/versent/jenkins/plugins/ignoreCommitterStrategy/IgnoreCommitterStrategySimpleTest.java
+++ b/src/test/java/au/com/versent/jenkins/plugins/ignoreCommitterStrategy/IgnoreCommitterStrategySimpleTest.java
@@ -1,0 +1,63 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Versent
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package au.com.versent.jenkins.plugins.ignoreCommitterStrategy;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import org.junit.jupiter.api.Test;
+
+public class IgnoreCommitterStrategySimpleTest {
+
+    private IgnoreCommitterStrategy strategy;
+    private String ignoredAuthors = "";
+    private boolean allowBuildIfNotExcludedAuthor = false;
+
+    public IgnoreCommitterStrategySimpleTest() {
+        strategy = new IgnoreCommitterStrategy(ignoredAuthors, allowBuildIfNotExcludedAuthor);
+    }
+
+    @Test
+    public void testGetIgnoredAuthors() {
+        assertThat(strategy.getIgnoredAuthors(), is(ignoredAuthors));
+    }
+
+    @Test
+    public void testGetAllowBuildIfNotExcludedAuthor() {
+        assertThat(strategy.getAllowBuildIfNotExcludedAuthor(), is(allowBuildIfNotExcludedAuthor));
+    }
+
+    @Test
+    public void testGetIgnoredAuthorsNonEmpty() {
+        ignoredAuthors = "ignored@example.com";
+        strategy = new IgnoreCommitterStrategy(ignoredAuthors, allowBuildIfNotExcludedAuthor);
+        assertThat(strategy.getIgnoredAuthors(), is(ignoredAuthors));
+    }
+
+    @Test
+    public void testGetAllowBuildIfNotExcludedAuthorNegation() {
+        allowBuildIfNotExcludedAuthor = !allowBuildIfNotExcludedAuthor;
+        strategy = new IgnoreCommitterStrategy(ignoredAuthors, allowBuildIfNotExcludedAuthor);
+        assertThat(strategy.getAllowBuildIfNotExcludedAuthor(), is(allowBuildIfNotExcludedAuthor));
+    }
+}

--- a/src/test/java/au/com/versent/jenkins/plugins/ignoreCommitterStrategy/IgnoreCommitterStrategyTest.java
+++ b/src/test/java/au/com/versent/jenkins/plugins/ignoreCommitterStrategy/IgnoreCommitterStrategyTest.java
@@ -97,14 +97,14 @@ public class IgnoreCommitterStrategyTest {
     }
 
     private final Random picker = new Random();
+    private static final String KNOWN_AUTHOR = "gits@mplereporule";
 
     private String getKnownAuthor() {
-        String known = "gits@mpleRepoRule";
         String[] knownAuthors = {
-            known,
-            "other@example.com," + known,
-            known + ",not-other@example.com",
-            "other@example.com," + known + ",not-other@example.com"
+            KNOWN_AUTHOR,
+            "other@example.com," + KNOWN_AUTHOR,
+            KNOWN_AUTHOR + ",not-other@example.com",
+            "other@example.com," + KNOWN_AUTHOR + ",not-other@example.com"
         };
         return knownAuthors[picker.nextInt(knownAuthors.length)];
     }
@@ -124,7 +124,7 @@ public class IgnoreCommitterStrategyTest {
     public void testIsAutomaticBuildEmptyIgnoredAuthorsTrue() {
         strategy = new IgnoreCommitterStrategy("", true);
         boolean result = strategy.isAutomaticBuild(source, head, current, previous, lastSeen, listener);
-        String msg = "Changeset contains non ignored author gits@mplereporule";
+        String msg = "Changeset contains non ignored author " + KNOWN_AUTHOR;
         assertThat(baos.toString(Charset.defaultCharset()), containsString(msg));
         assertTrue(result);
     }
@@ -151,7 +151,7 @@ public class IgnoreCommitterStrategyTest {
     public void testIsAutomaticBuildValidIgnoredAuthorFalse() {
         strategy = new IgnoreCommitterStrategy(getKnownAuthor(), false);
         boolean result = strategy.isAutomaticBuild(source, head, current, previous, lastSeen, listener);
-        String msg = "Changeset contains ignored author gits@mplereporule";
+        String msg = "Changeset contains ignored author " + KNOWN_AUTHOR;
         assertThat(baos.toString(Charset.defaultCharset()), containsString(msg));
         String msg2 = "allowBuildIfNotExcludedAuthor is false, therefore build is not required";
         assertThat(baos.toString(Charset.defaultCharset()), containsString(msg2));
@@ -171,7 +171,7 @@ public class IgnoreCommitterStrategyTest {
     public void testIsAutomaticBuildValidIgnoredAuthorNullRevisionFalse() {
         strategy = new IgnoreCommitterStrategy(getKnownAuthor(), false);
         boolean result = strategy.isAutomaticBuild(source, head, current, previous, null, listener);
-        String msg = "Changeset contains ignored author gits@mplereporule";
+        String msg = "Changeset contains ignored author " + KNOWN_AUTHOR;
         assertThat(baos.toString(Charset.defaultCharset()), containsString(msg));
         String msg2 = "allowBuildIfNotExcludedAuthor is false, therefore build is not required";
         assertThat(baos.toString(Charset.defaultCharset()), containsString(msg2));
@@ -186,7 +186,7 @@ public class IgnoreCommitterStrategyTest {
         boolean result = strategy.isAutomaticBuild(source, head, myCurrent, myPrevious, myPrevious, listener);
         assertThat(
                 baos.toString(Charset.defaultCharset()),
-                containsString("Changeset contains ignored author gits@mplereporule"));
+                containsString("Changeset contains ignored author " + KNOWN_AUTHOR));
         assertFalse(result);
     }
 
@@ -207,7 +207,7 @@ public class IgnoreCommitterStrategyTest {
         MySCMRevision myCurrent = new MySCMRevision(current.getHead(), commit2);
         MySCMRevision myPrevious = new MySCMRevision(current.getHead(), commit1);
         boolean result = strategy.isAutomaticBuild(source, head, myCurrent, myPrevious, myPrevious, listener);
-        String msg = "Changeset contains non ignored author gits@mplereporule";
+        String msg = "Changeset contains non ignored author " + KNOWN_AUTHOR;
         assertThat(baos.toString(Charset.defaultCharset()), containsString(msg));
         assertTrue(result);
     }
@@ -286,7 +286,7 @@ public class IgnoreCommitterStrategyTest {
     // Incorrect value test case - null owner
     @Test
     public void testNullOwner() {
-        strategy = new IgnoreCommitterStrategy("gits@mpleRepoRule", false);
+        strategy = new IgnoreCommitterStrategy(getKnownAuthor(), false);
         source.setOwner(null);
         boolean result = strategy.isAutomaticBuild(source, head, current, previous, lastSeen, listener);
         assertThat(baos.toString(Charset.defaultCharset()), startsWith("ERROR: Error retrieving SCMSourceOwner"));

--- a/src/test/java/au/com/versent/jenkins/plugins/ignoreCommitterStrategy/IgnoreCommitterStrategyTest.java
+++ b/src/test/java/au/com/versent/jenkins/plugins/ignoreCommitterStrategy/IgnoreCommitterStrategyTest.java
@@ -23,213 +23,109 @@
  */
 package au.com.versent.jenkins.plugins.ignoreCommitterStrategy;
 
-
-import edu.umd.cs.findbugs.annotations.NonNull;
-import hudson.model.Item;
-import hudson.model.ItemGroup;
-import hudson.model.Job;
-import hudson.plugins.git.GitSCM;
-import hudson.scm.SCM;
-import hudson.search.Search;
-import hudson.search.SearchIndex;
-import hudson.security.ACL;
-import jenkins.branch.MultiBranchProject;
+import hudson.model.TaskListener;
+import jenkins.plugins.git.GitRefSCMHead;
+import jenkins.plugins.git.GitRefSCMRevision;
 import jenkins.plugins.git.GitSCMSource;
-import jenkins.scm.api.SCMHead;
-
-import static jenkins.plugins.git.AbstractGitSCMSource.SCMRevisionImpl;
-
-import jenkins.plugins.git.GitSCMFileSystem;
+import jenkins.plugins.git.GitSampleRepoRule;
+import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.SCMSource;
-import jenkins.scm.api.SCMSourceCriteria;
 import jenkins.scm.api.SCMSourceOwner;
-import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.core.classloader.annotations.PrepareForTest;
 
-import java.io.ByteArrayOutputStream;
-
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Arrays;
-
-import org.junit.Before;
-
-import javax.annotation.Nonnull;
-
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({IgnoreCommitterStrategy.class, GitSCMSource.class})
 public class IgnoreCommitterStrategyTest {
-    private SCMHead head;
-    private GitSCMSource source;
-    private SCMRevisionImpl currRevision;
-    private SCMRevisionImpl prevRevision;
-    private List<String> ignoredAuthors = Arrays.asList("jenkins@example.com", "jenkins-ci@example.com");
-    private List<String> nonIgnoredAuthors = Arrays.asList("hello@example.com", "john.galt@whois.com");
-    private SCM scm;
+
+    @ClassRule
+    public static JenkinsRule r = new JenkinsRule();
+
+    @ClassRule
+    public static GitSampleRepoRule sampleRepo = new GitSampleRepoRule();
+
+    private IgnoreCommitterStrategy strategy;
+
+    public IgnoreCommitterStrategyTest() {
+    }
+
+    private static String branchName;
+    private static String commit1, commit2, commit3;
+
+    @BeforeClass
+    public static void createGitRepository() throws Exception {
+        branchName = "is-automatic-build-test-branch";
+        sampleRepo.init();
+        commit1 = sampleRepo.head();
+        sampleRepo.git("checkout", "-b", branchName);
+        sampleRepo.write("file", "modified-file");
+        sampleRepo.git("commit", "--all", "--message=commit-1-to-branch-" + branchName);
+        commit2 = sampleRepo.head();
+        sampleRepo.write("file", "modified-file-again");
+        sampleRepo.git("commit", "--all", "--message=commit-2-to-branch-" + branchName);
+        commit3 = sampleRepo.head();
+    }
+
+    private SCMSource source;
+    private SCMSourceOwner owner;
+    private GitRefSCMHead head;
+    private SCMRevision currRevision, prevRevision, lastSeenRevision;
+    private TaskListener listener;
 
     @Before
-    public void setUp() {
-        GitSCMSource sourceMock = PowerMockito.mock(GitSCMSource.class);
-
-        this.head = new SCMHead("test-branch");
-        this.source = sourceMock;
-        this.currRevision = new SCMRevisionImpl(head, "222");
-        this.prevRevision = new SCMRevisionImpl(head, "111");
-        this.scm = new GitSCM("http://example.com.au");
+    public void createSCMSource() {
+        source = new GitSCMSource(sampleRepo.toString());
+        owner = Mockito.mock(FakeSCMSourceOwner.class);
+        source.setOwner(owner);
+        head = new GitRefSCMHead(branchName);
+        currRevision = new GitRefSCMRevision(head, commit3);
+        prevRevision = new GitRefSCMRevision(head, commit2);
+        lastSeenRevision = new GitRefSCMRevision(head, commit1);
+        listener = TaskListener.NULL;
     }
 
     @Test
-    public void testIsAutomaticBuildReturnsTrueIfAllAuthorsAreNotIgnored() throws Exception {
-
-        String commits = "";
-        for (String author : nonIgnoredAuthors) {
-            commits += getCommit(author);
-        }
-
-        assertTrue(setupIgnoreCommitterStrategy(commits));
+    public void testIsAutomaticBuildEmptyIgnoredAuthors() throws Throwable {
+        strategy = new IgnoreCommitterStrategy("", true);
+        assertTrue(strategy.isAutomaticBuild(source, head, currRevision, prevRevision, lastSeenRevision, listener));
     }
 
     @Test
-    public void testIsAutomaticBuildReturnsTrueIfOneAuthorIsNotIgnoredAndAllowBuildIfNotExcludedAuthor() throws Exception {
-
-        String commits = "";
-        for (String author : ignoredAuthors) {
-            commits += getCommit(author);
-        }
-        for (String author : nonIgnoredAuthors) {
-            commits += getCommit(author);
-        }
-
-        assertTrue(setupIgnoreCommitterStrategy(commits));
+    public void testIsAutomaticBuildEmptyIgnoredAuthorsNoBuildIfExcluded() throws Throwable {
+        strategy = new IgnoreCommitterStrategy("", false);
+        assertTrue(strategy.isAutomaticBuild(source, head, currRevision, prevRevision, lastSeenRevision, listener));
     }
 
     @Test
-    public void testIsAutomaticBuildReturnsFalseIfAllAuthorsAreIgnoredAndAllowBuildIfNotExcludedAuthor() throws Exception {
-
-        String commits = "";
-        for (String author : ignoredAuthors) {
-            commits += getCommit(author);
-        }
-
-        assertFalse(setupIgnoreCommitterStrategy(commits));
+    public void testIsAutomaticBuildValidIgnoredAuthor() throws Throwable {
+        strategy = new IgnoreCommitterStrategy("gits@mpleRepoRule", true); // Author from sampleRepoRule
+        assertFalse(strategy.isAutomaticBuild(source, head, currRevision, prevRevision, lastSeenRevision, listener));
     }
 
     @Test
-    public void testIsAutomaticBuildReturnsFalseIfOneAuthorIsIgnored() throws Exception {
-
-        String commits = "";
-
-        for (String author : nonIgnoredAuthors) {
-            commits += getCommit(author);
-        }
-
-        for (String author : ignoredAuthors) {
-            commits += getCommit(author);
-        }
-
-        assertFalse(setupIgnoreCommitterStrategy(commits));
+    public void testIsAutomaticBuildValidIgnoredAuthors() throws Throwable {
+        strategy = new IgnoreCommitterStrategy("gits@mpleRepoRule,ignore@example.com", true); // Author from sampleRepoRule
+        assertFalse(strategy.isAutomaticBuild(source, head, currRevision, prevRevision, lastSeenRevision, listener));
     }
 
     @Test
-    public void testIsAutomaticBuildReturnsTrueIfCommitCantbeParsed() throws Exception {
-
-        String commits = "";
-
-        for (String author : nonIgnoredAuthors) {
-            commits += getBrokenCommit(author);
-        }
-
-        assertTrue(setupIgnoreCommitterStrategy(commits));
+    public void testIsAutomaticBuildValidIgnoredAuthorsNoBuildIfExcluded() throws Throwable {
+        strategy = new IgnoreCommitterStrategy("ignore@example.com,gits@mpleRepoRule", false); // Author from sampleRepoRule
+        assertFalse(strategy.isAutomaticBuild(source, head, currRevision, prevRevision, lastSeenRevision, listener));
     }
 
-    private boolean setupIgnoreCommitterStrategy(String commits) throws Exception {
-        // prepare mock GitSCMFileSystem to be returned by builderMock
-        GitSCMFileSystem fileSystemMock = Mockito.mock(GitSCMFileSystem.class);
-        // mock builderMock to build a mocked GitSCMFileSystem
-        GitSCMFileSystem.BuilderImpl builderMock = Mockito.mock(GitSCMFileSystem.BuilderImpl.class);
-        // mock ByteArrayOutputStream to return preset response
-        ByteArrayOutputStream ByteArrayOutputStreamMock = Mockito.mock(ByteArrayOutputStream.class);
-        // mock ownerMock
-        SCMSourceOwner ownerMock = PowerMockito.mock(WorkflowMultiBranchProject.class);
-
-        try {
-            PowerMockito.when(source.build(head, currRevision)).thenReturn(scm);
-            PowerMockito.when(source.getOwner()).thenReturn(ownerMock);
-
-            // set returns for mocked methods
-            Mockito.when(ByteArrayOutputStreamMock.toByteArray()).thenReturn(commits.getBytes());
-            Mockito.when(builderMock.build(source.getOwner(), scm, currRevision)).thenReturn(fileSystemMock);
-            Mockito.when(fileSystemMock.changesSince(prevRevision, ByteArrayOutputStreamMock)).thenReturn(true);
-
-            // mock classes in the tested target class to return mocked  objects when initiated
-            PowerMockito.whenNew(ByteArrayOutputStream.class).withNoArguments().thenReturn(ByteArrayOutputStreamMock);
-            PowerMockito.whenNew(GitSCMFileSystem.BuilderImpl.class).withNoArguments().thenReturn(builderMock);
-
-            IgnoreCommitterStrategy IgnoreCommitterStrategy = new IgnoreCommitterStrategy(
-                    String.join(",", ignoredAuthors), false
-            );
-
-            return IgnoreCommitterStrategy.isAutomaticBuild(source, head, currRevision, prevRevision);
-        } catch (Exception e) {
-            throw e;
-        }
+    private static abstract class FakeSCMSourceOwner implements SCMSourceOwner {
     }
 
-    private String getCommit(String authorEmail) {
-        List<String> lines = new ArrayList<String>();
-        lines.add(String.format("commit %s", "1567861636cd854f4dd6fa40bf94c0c657681dd5"));
-        lines.add(String.format("author John Galt<%s> 1363879004 +0100", authorEmail));
-        lines.add("");
-        lines.add("    [task] Updated version.");
-        lines.add("    ");
-        lines.add("    Including earlier updates.");
-        lines.add("    ");
-        lines.add("    Changes in this version:");
-        lines.add("    - Changed to take the gerrit url from gerrit query command.");
-        lines.add("    - Aligned reason information with our new commit hooks");
-        lines.add("    ");
-        lines.add("    Change-Id: Ife96d2abed5b066d9620034bec5f04cf74b8c66d");
-        lines.add("    Reviewed-on: https://gerrit.e.se/12345");
-        lines.add("    Tested-by: Jenkins <jenkins@no-mail.com>");
-        lines.add("    Reviewed-by: Mister Another <mister.another@ericsson.com>");
-
-
-        return String.join("\n", lines);
-    }
-
-    private String getBrokenCommit(String authorEmail) {
-        List<String> lines = new ArrayList<String>();
-        lines.add(String.format("commit %s", "1567861636cd854f4dd6fa40bf94c0c657681dd5"));
-        lines.add(String.format("Authorzzz John Galt<%s> 1363879004 +0100", authorEmail));
-        lines.add("");
-        lines.add("    [task] Updated version.");
-        lines.add("    ");
-        lines.add("    Including earlier updates.");
-        lines.add("    ");
-        lines.add("    Changes in this version:");
-        lines.add("    - Changed to take the gerrit url from gerrit query command.");
-        lines.add("    - Aligned reason information with our new commit hooks");
-        lines.add("    ");
-        lines.add("    Change-Id: Ife96d2abed5b066d9620034bec5f04cf74b8c66d");
-        lines.add("    Reviewed-on: https://gerrit.e.se/12345");
-        lines.add("    Tested-by: Jenkins <jenkins@no-mail.com>");
-        lines.add("    Reviewed-by: Mister Another <mister.another@ericsson.com>");
-
-
-        return String.join("\n", lines);
+    // Incorrect value test case - null owner
+    @Test
+    public void testNullOwner() throws Throwable {
+        strategy = new IgnoreCommitterStrategy("gits@mpleRepoRule", false);
+        source.setOwner(null);
+        assertTrue(strategy.isAutomaticBuild(source, head, currRevision, prevRevision, lastSeenRevision, listener));
     }
 }

--- a/src/test/java/au/com/versent/jenkins/plugins/ignoreCommitterStrategy/IgnoreCommitterStrategyTest.java
+++ b/src/test/java/au/com/versent/jenkins/plugins/ignoreCommitterStrategy/IgnoreCommitterStrategyTest.java
@@ -87,55 +87,55 @@ public class IgnoreCommitterStrategyTest {
     }
 
     @Test
-    public void testIsAutomaticBuildEmptyIgnoredAuthors() throws Throwable {
+    public void testIsAutomaticBuildEmptyIgnoredAuthors() {
         strategy = new IgnoreCommitterStrategy("", true);
         assertTrue(strategy.isAutomaticBuild(source, head, currRevision, prevRevision, lastSeenRevision, listener));
     }
 
     @Test
-    public void testIsAutomaticBuildEmptyIgnoredAuthorsNoBuildIfExcluded() throws Throwable {
+    public void testIsAutomaticBuildEmptyIgnoredAuthorsNoBuildIfExcluded() {
         strategy = new IgnoreCommitterStrategy("", false);
         assertTrue(strategy.isAutomaticBuild(source, head, currRevision, prevRevision, lastSeenRevision, listener));
     }
 
     @Test
-    public void testIsAutomaticBuildValidIgnoredAuthor() throws Throwable {
+    public void testIsAutomaticBuildValidIgnoredAuthor() {
         strategy = new IgnoreCommitterStrategy("gits@mpleRepoRule", true); // Author from sampleRepoRule
         assertFalse(strategy.isAutomaticBuild(source, head, currRevision, prevRevision, lastSeenRevision, listener));
     }
 
     @Test
-    public void testIsAutomaticBuildValidIgnoredAuthors() throws Throwable {
+    public void testIsAutomaticBuildValidIgnoredAuthors() {
         strategy = new IgnoreCommitterStrategy("gits@mpleRepoRule,ignore@example.com", true);
         assertFalse(strategy.isAutomaticBuild(source, head, currRevision, prevRevision, lastSeenRevision, listener));
     }
 
     @Test
-    public void testIsAutomaticBuildValidIgnoredAuthorsNoBuildIfExcluded() throws Throwable {
+    public void testIsAutomaticBuildValidIgnoredAuthorsNoBuildIfExcluded() {
         strategy = new IgnoreCommitterStrategy("ignore@example.com,gits@mpleRepoRule", false);
         assertFalse(strategy.isAutomaticBuild(source, head, currRevision, prevRevision, lastSeenRevision, listener));
     }
 
     @Test
-    public void testIsAutomaticBuildValidIgnoredAuthorNullRevision() throws Throwable {
+    public void testIsAutomaticBuildValidIgnoredAuthorNullRevision() {
         strategy = new IgnoreCommitterStrategy("gits@mpleRepoRule,other@example.com", true);
         assertFalse(strategy.isAutomaticBuild(source, head, currRevision, prevRevision, null, listener));
     }
 
     @Test
-    public void testIsAutomaticBuildValidIgnoredAuthorsNullRevision() throws Throwable {
+    public void testIsAutomaticBuildValidIgnoredAuthorsNullRevision() {
         strategy = new IgnoreCommitterStrategy("gits@mpleRepoRule,ignore@example.com,other@example.com", true);
         assertFalse(strategy.isAutomaticBuild(source, head, currRevision, null, lastSeenRevision, listener));
     }
 
     @Test
-    public void testIsAutomaticBuildValidIgnoredAuthorsNullRevisions() throws Throwable {
+    public void testIsAutomaticBuildValidIgnoredAuthorsNullRevisions() {
         strategy = new IgnoreCommitterStrategy("gits@mpleRepoRule,ignore@example.com,other@example.com", true);
         assertFalse(strategy.isAutomaticBuild(source, head, currRevision, null, null, listener));
     }
 
     @Test
-    public void testIsAutomaticBuildValidIgnoredAuthorsNoBuildIfExcludedNullRevision() throws Throwable {
+    public void testIsAutomaticBuildValidIgnoredAuthorsNoBuildIfExcludedNullRevision() {
         strategy = new IgnoreCommitterStrategy("ignore@example.com,gits@mpleRepoRule", false);
         assertFalse(strategy.isAutomaticBuild(source, head, null, prevRevision, lastSeenRevision, listener));
     }
@@ -145,7 +145,7 @@ public class IgnoreCommitterStrategyTest {
 
     // Incorrect value test case - null owner
     @Test
-    public void testNullOwner() throws Throwable {
+    public void testNullOwner() {
         strategy = new IgnoreCommitterStrategy("gits@mpleRepoRule", false);
         source.setOwner(null);
         assertTrue(strategy.isAutomaticBuild(source, head, currRevision, prevRevision, lastSeenRevision, listener));

--- a/src/test/java/au/com/versent/jenkins/plugins/ignoreCommitterStrategy/IgnoreCommitterStrategyTest.java
+++ b/src/test/java/au/com/versent/jenkins/plugins/ignoreCommitterStrategy/IgnoreCommitterStrategyTest.java
@@ -233,6 +233,16 @@ public class IgnoreCommitterStrategyTest {
         assertTrue(result);
     }
 
+    @Test
+    public void testSCMRevisionNotGitRefSCMRevisionAndTooShort() {
+        strategy = new IgnoreCommitterStrategy(getKnownAuthor(), false);
+        MySCMRevision myCurrent = new MySCMRevision(current.getHead(), "deed"); // Valid SHA1 but too short
+        boolean result = strategy.isAutomaticBuild(source, head, myCurrent, myCurrent, myCurrent, listener);
+        String msg = "ERROR: Exception: java.lang.StringIndexOutOfBoundsException";
+        assertThat(baos.toString(Charset.defaultCharset()), containsString(msg));
+        assertTrue(result);
+    }
+
     private static class MySCMRevision extends SCMRevision {
 
         private final String hash;

--- a/src/test/java/au/com/versent/jenkins/plugins/ignoreCommitterStrategy/IgnoreCommitterStrategyTest.java
+++ b/src/test/java/au/com/versent/jenkins/plugins/ignoreCommitterStrategy/IgnoreCommitterStrategyTest.java
@@ -79,7 +79,7 @@ public class IgnoreCommitterStrategyTest {
     private SCMSource source;
     private SCMSourceOwner owner;
     private GitRefSCMHead head;
-    private SCMRevision currRevision, prevRevision, lastSeenRevision;
+    private SCMRevision current, previous, lastSeen;
     private TaskListener listener;
     private ByteArrayOutputStream baos;
 
@@ -89,9 +89,9 @@ public class IgnoreCommitterStrategyTest {
         owner = Mockito.mock(FakeSCMSourceOwner.class);
         source.setOwner(owner);
         head = new GitRefSCMHead(branchName);
-        currRevision = new GitRefSCMRevision(head, commit2);
-        prevRevision = new GitRefSCMRevision(head, commit1);
-        lastSeenRevision = prevRevision;
+        current = new GitRefSCMRevision(head, commit2);
+        previous = new GitRefSCMRevision(head, commit1);
+        lastSeen = previous;
         baos = new ByteArrayOutputStream();
         listener = new StreamTaskListener(baos, Charset.defaultCharset());
     }
@@ -123,8 +123,7 @@ public class IgnoreCommitterStrategyTest {
     @Test
     public void testIsAutomaticBuildEmptyIgnoredAuthorsTrue() {
         strategy = new IgnoreCommitterStrategy("", true);
-        boolean result =
-                strategy.isAutomaticBuild(source, head, currRevision, prevRevision, lastSeenRevision, listener);
+        boolean result = strategy.isAutomaticBuild(source, head, current, previous, lastSeen, listener);
         String msg = "Changeset contains non ignored author gits@mplereporule";
         assertThat(baos.toString(Charset.defaultCharset()), containsString(msg));
         assertTrue(result);
@@ -133,8 +132,7 @@ public class IgnoreCommitterStrategyTest {
     @Test
     public void testIsAutomaticBuildEmptyIgnoredAuthorsFalse() {
         strategy = new IgnoreCommitterStrategy("", false);
-        boolean result =
-                strategy.isAutomaticBuild(source, head, currRevision, prevRevision, lastSeenRevision, listener);
+        boolean result = strategy.isAutomaticBuild(source, head, current, previous, lastSeen, listener);
         String msg = "All commits in the changeset are made by non-excluded authors, build is true";
         assertThat(baos.toString(Charset.defaultCharset()), containsString(msg));
         assertTrue(result);
@@ -143,8 +141,7 @@ public class IgnoreCommitterStrategyTest {
     @Test
     public void testIsAutomaticBuildValidIgnoredAuthorTrue() {
         strategy = new IgnoreCommitterStrategy(getKnownAuthor(), true);
-        boolean result =
-                strategy.isAutomaticBuild(source, head, currRevision, prevRevision, lastSeenRevision, listener);
+        boolean result = strategy.isAutomaticBuild(source, head, current, previous, lastSeen, listener);
         String msg = "All commits in the changeset are made by excluded authors, build is false";
         assertThat(baos.toString(Charset.defaultCharset()), containsString(msg));
         assertFalse(result);
@@ -153,8 +150,7 @@ public class IgnoreCommitterStrategyTest {
     @Test
     public void testIsAutomaticBuildValidIgnoredAuthorFalse() {
         strategy = new IgnoreCommitterStrategy(getKnownAuthor(), false);
-        boolean result =
-                strategy.isAutomaticBuild(source, head, currRevision, prevRevision, lastSeenRevision, listener);
+        boolean result = strategy.isAutomaticBuild(source, head, current, previous, lastSeen, listener);
         String msg = "Changeset contains ignored author gits@mplereporule";
         assertThat(baos.toString(Charset.defaultCharset()), containsString(msg));
         String msg2 = "allowBuildIfNotExcludedAuthor is false, therefore build is not required";
@@ -165,7 +161,7 @@ public class IgnoreCommitterStrategyTest {
     @Test
     public void testIsAutomaticBuildValidIgnoredAuthorNullRevisionTrue() {
         strategy = new IgnoreCommitterStrategy(getKnownAuthor(), true);
-        boolean result = strategy.isAutomaticBuild(source, head, currRevision, prevRevision, null, listener);
+        boolean result = strategy.isAutomaticBuild(source, head, current, previous, null, listener);
         String msg = "All commits in the changeset are made by excluded authors, build is false";
         assertThat(baos.toString(Charset.defaultCharset()), containsString(msg));
         assertFalse(result);
@@ -174,7 +170,7 @@ public class IgnoreCommitterStrategyTest {
     @Test
     public void testIsAutomaticBuildValidIgnoredAuthorNullRevisionFalse() {
         strategy = new IgnoreCommitterStrategy(getKnownAuthor(), false);
-        boolean result = strategy.isAutomaticBuild(source, head, currRevision, prevRevision, null, listener);
+        boolean result = strategy.isAutomaticBuild(source, head, current, previous, null, listener);
         String msg = "Changeset contains ignored author gits@mplereporule";
         assertThat(baos.toString(Charset.defaultCharset()), containsString(msg));
         String msg2 = "allowBuildIfNotExcludedAuthor is false, therefore build is not required";
@@ -185,10 +181,9 @@ public class IgnoreCommitterStrategyTest {
     @Test
     public void testSCMRevisionNotGitRefSCMRevision() {
         strategy = new IgnoreCommitterStrategy(getKnownAuthor(), false);
-        MySCMRevision latestrevision = new MySCMRevision(currRevision.getHead(), commit2);
-        MySCMRevision priorRevision = new MySCMRevision(currRevision.getHead(), commit1);
-        boolean result =
-                strategy.isAutomaticBuild(source, head, latestrevision, priorRevision, priorRevision, listener);
+        MySCMRevision myCurrent = new MySCMRevision(current.getHead(), commit2);
+        MySCMRevision myPrevious = new MySCMRevision(current.getHead(), commit1);
+        boolean result = strategy.isAutomaticBuild(source, head, myCurrent, myPrevious, myPrevious, listener);
         assertThat(
                 baos.toString(Charset.defaultCharset()),
                 containsString("Changeset contains ignored author gits@mplereporule"));
@@ -198,10 +193,9 @@ public class IgnoreCommitterStrategyTest {
     @Test
     public void testSCMRevisionNotGitRefSCMRevisionAllowBuildsIfExcludedAuthor() {
         strategy = new IgnoreCommitterStrategy(getKnownAuthor(), true);
-        MySCMRevision latestrevision = new MySCMRevision(currRevision.getHead(), commit2);
-        MySCMRevision priorRevision = new MySCMRevision(currRevision.getHead(), commit1);
-        boolean result =
-                strategy.isAutomaticBuild(source, head, latestrevision, priorRevision, priorRevision, listener);
+        MySCMRevision myCurrent = new MySCMRevision(current.getHead(), commit2);
+        MySCMRevision myPrevious = new MySCMRevision(current.getHead(), commit1);
+        boolean result = strategy.isAutomaticBuild(source, head, myCurrent, myPrevious, myPrevious, listener);
         String msg = "All commits in the changeset are made by excluded authors, build is false";
         assertThat(baos.toString(Charset.defaultCharset()), containsString(msg));
         assertFalse(result);
@@ -210,10 +204,9 @@ public class IgnoreCommitterStrategyTest {
     @Test
     public void testSCMRevisionNotGitRefSCMRevisionNoExcludingAuthorTrue() {
         strategy = new IgnoreCommitterStrategy(getUnknownAuthor(), true);
-        MySCMRevision latestrevision = new MySCMRevision(currRevision.getHead(), commit2);
-        MySCMRevision priorRevision = new MySCMRevision(currRevision.getHead(), commit1);
-        boolean result =
-                strategy.isAutomaticBuild(source, head, latestrevision, priorRevision, priorRevision, listener);
+        MySCMRevision myCurrent = new MySCMRevision(current.getHead(), commit2);
+        MySCMRevision myPrevious = new MySCMRevision(current.getHead(), commit1);
+        boolean result = strategy.isAutomaticBuild(source, head, myCurrent, myPrevious, myPrevious, listener);
         String msg = "Changeset contains non ignored author gits@mplereporule";
         assertThat(baos.toString(Charset.defaultCharset()), containsString(msg));
         assertTrue(result);
@@ -222,10 +215,9 @@ public class IgnoreCommitterStrategyTest {
     @Test
     public void testSCMRevisionNotGitRefSCMRevisionNoExcludingAuthorFalse() {
         strategy = new IgnoreCommitterStrategy(getUnknownAuthor(), false);
-        MySCMRevision latestrevision = new MySCMRevision(currRevision.getHead(), commit2);
-        MySCMRevision priorRevision = new MySCMRevision(currRevision.getHead(), commit1);
-        boolean result =
-                strategy.isAutomaticBuild(source, head, latestrevision, priorRevision, priorRevision, listener);
+        MySCMRevision myCurrent = new MySCMRevision(current.getHead(), commit2);
+        MySCMRevision myPrevious = new MySCMRevision(current.getHead(), commit1);
+        boolean result = strategy.isAutomaticBuild(source, head, myCurrent, myPrevious, myPrevious, listener);
         String msg = "All commits in the changeset are made by non-excluded authors, build is true";
         assertThat(baos.toString(Charset.defaultCharset()), containsString(msg));
         assertTrue(result);
@@ -234,8 +226,8 @@ public class IgnoreCommitterStrategyTest {
     @Test
     public void testSCMRevisionNotGitRefSCMRevisionAndInvalidHash() {
         strategy = new IgnoreCommitterStrategy(getKnownAuthor(), false);
-        MySCMRevision revision = new MySCMRevision(currRevision.getHead(), "0000" + commit1);
-        boolean result = strategy.isAutomaticBuild(source, head, revision, revision, revision, listener);
+        MySCMRevision myCurrent = new MySCMRevision(current.getHead(), "0000" + commit1);
+        boolean result = strategy.isAutomaticBuild(source, head, myCurrent, myCurrent, myCurrent, listener);
         String msg = "All commits in the changeset are made by non-excluded authors, build is true";
         assertThat(baos.toString(Charset.defaultCharset()), containsString(msg));
         assertTrue(result);
@@ -286,8 +278,7 @@ public class IgnoreCommitterStrategyTest {
     public void testNullOwner() {
         strategy = new IgnoreCommitterStrategy("gits@mpleRepoRule", false);
         source.setOwner(null);
-        boolean result =
-                strategy.isAutomaticBuild(source, head, currRevision, prevRevision, lastSeenRevision, listener);
+        boolean result = strategy.isAutomaticBuild(source, head, current, previous, lastSeen, listener);
         assertThat(baos.toString(Charset.defaultCharset()), startsWith("ERROR: Error retrieving SCMSourceOwner"));
         assertTrue(result);
     }

--- a/src/test/java/au/com/versent/jenkins/plugins/ignoreCommitterStrategy/IgnoreCommitterStrategyTest.java
+++ b/src/test/java/au/com/versent/jenkins/plugins/ignoreCommitterStrategy/IgnoreCommitterStrategyTest.java
@@ -151,6 +151,7 @@ public class IgnoreCommitterStrategyTest {
         boolean result = strategy.isAutomaticBuild(source, head, currRevision, prevRevision, null, listener);
         String msg = "Ignored authors: [gits@mplereporule, other@example.com]";
         assertThat(baos.toString(Charset.defaultCharset()), startsWith(msg));
+        assertFalse(result);
     }
 
     @Test
@@ -159,6 +160,7 @@ public class IgnoreCommitterStrategyTest {
         boolean result = strategy.isAutomaticBuild(source, head, currRevision, null, lastSeenRevision, listener);
         String msg = "Ignored authors: [gits@mplereporule, ignore@example.com, other@example.com]";
         assertThat(baos.toString(Charset.defaultCharset()), startsWith(msg));
+        assertFalse(result);
     }
 
     @Test
@@ -167,6 +169,7 @@ public class IgnoreCommitterStrategyTest {
         boolean result = strategy.isAutomaticBuild(source, head, currRevision, null, null, listener);
         String msg = "Ignored authors: [gits@mplereporule, ignore@example.com, other@example.com]";
         assertThat(baos.toString(Charset.defaultCharset()), startsWith(msg));
+        assertFalse(result);
     }
 
     @Test
@@ -178,6 +181,7 @@ public class IgnoreCommitterStrategyTest {
         assertThat(
                 baos.toString(Charset.defaultCharset()),
                 containsString("Changeset contains ignored author gits@mplereporule"));
+        assertFalse(result);
     }
 
     private abstract static class FakeSCMSourceOwner implements SCMSourceOwner {}

--- a/src/test/java/au/com/versent/jenkins/plugins/ignoreCommitterStrategy/IgnoreCommitterStrategyTest.java
+++ b/src/test/java/au/com/versent/jenkins/plugins/ignoreCommitterStrategy/IgnoreCommitterStrategyTest.java
@@ -30,6 +30,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import hudson.model.TaskListener;
+import hudson.scm.SubversionSCM;
 import hudson.util.StreamTaskListener;
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.Charset;
@@ -43,6 +44,7 @@ import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.SCMSourceOwner;
+import jenkins.scm.impl.SingleSCMSource;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -290,6 +292,18 @@ public class IgnoreCommitterStrategyTest {
         source.setOwner(null);
         boolean result = strategy.isAutomaticBuild(source, head, current, previous, lastSeen, listener);
         assertThat(baos.toString(Charset.defaultCharset()), startsWith("ERROR: Error retrieving SCMSourceOwner"));
+        assertTrue(result);
+    }
+
+    // Unsupported SCMSource test case, cannot retreive SCMFileSystem
+    @Test
+    public void testUnsupportedSCMSource() {
+        strategy = new IgnoreCommitterStrategy(getKnownAuthor(), false);
+        SubversionSCM scm = new SubversionSCM("http://svn.apache.org/repos/asf/xml/trunk");
+        SCMSource unsupportedSource = new SingleSCMSource("Subversion", scm);
+        unsupportedSource.setOwner(source.getOwner());
+        boolean result = strategy.isAutomaticBuild(unsupportedSource, head, current, previous, lastSeen, listener);
+        assertThat(baos.toString(Charset.defaultCharset()), startsWith("ERROR: Error retrieving SCMFileSystem"));
         assertTrue(result);
     }
 }

--- a/src/test/java/au/com/versent/jenkins/plugins/ignoreCommitterStrategy/IgnoreCommitterStrategyTest.java
+++ b/src/test/java/au/com/versent/jenkins/plugins/ignoreCommitterStrategy/IgnoreCommitterStrategyTest.java
@@ -54,7 +54,7 @@ public class IgnoreCommitterStrategyTest {
     }
 
     private static String branchName;
-    private static String commit1, commit2, commit3;
+    private static String commit1, commit2;
 
     @BeforeClass
     public static void createGitRepository() throws Exception {
@@ -63,11 +63,8 @@ public class IgnoreCommitterStrategyTest {
         commit1 = sampleRepo.head();
         sampleRepo.git("checkout", "-b", branchName);
         sampleRepo.write("file", "modified-file");
-        sampleRepo.git("commit", "--all", "--message=commit-1-to-branch-" + branchName);
+        sampleRepo.git("commit", "--all", "--message=commit-to-branch-" + branchName);
         commit2 = sampleRepo.head();
-        sampleRepo.write("file", "modified-file-again");
-        sampleRepo.git("commit", "--all", "--message=commit-2-to-branch-" + branchName);
-        commit3 = sampleRepo.head();
     }
 
     private SCMSource source;
@@ -82,8 +79,8 @@ public class IgnoreCommitterStrategyTest {
         owner = Mockito.mock(FakeSCMSourceOwner.class);
         source.setOwner(owner);
         head = new GitRefSCMHead(branchName);
-        currRevision = new GitRefSCMRevision(head, commit3);
-        prevRevision = new GitRefSCMRevision(head, commit2);
+        currRevision = new GitRefSCMRevision(head, commit2);
+        prevRevision = new GitRefSCMRevision(head, commit1);
         lastSeenRevision = new GitRefSCMRevision(head, commit1);
         listener = TaskListener.NULL;
     }

--- a/src/test/java/au/com/versent/jenkins/plugins/ignoreCommitterStrategy/IgnoreCommitterStrategyTest.java
+++ b/src/test/java/au/com/versent/jenkins/plugins/ignoreCommitterStrategy/IgnoreCommitterStrategyTest.java
@@ -81,7 +81,7 @@ public class IgnoreCommitterStrategyTest {
         head = new GitRefSCMHead(branchName);
         currRevision = new GitRefSCMRevision(head, commit2);
         prevRevision = new GitRefSCMRevision(head, commit1);
-        lastSeenRevision = new GitRefSCMRevision(head, commit1);
+        lastSeenRevision = prevRevision;
         listener = TaskListener.NULL;
     }
 

--- a/src/test/java/au/com/versent/jenkins/plugins/ignoreCommitterStrategy/IgnoreCommitterStrategyTest.java
+++ b/src/test/java/au/com/versent/jenkins/plugins/ignoreCommitterStrategy/IgnoreCommitterStrategyTest.java
@@ -23,6 +23,9 @@
  */
 package au.com.versent.jenkins.plugins.ignoreCommitterStrategy;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import hudson.model.TaskListener;
 import jenkins.plugins.git.GitRefSCMHead;
 import jenkins.plugins.git.GitRefSCMRevision;
@@ -31,8 +34,6 @@ import jenkins.plugins.git.GitSampleRepoRule;
 import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.SCMSourceOwner;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -105,14 +106,38 @@ public class IgnoreCommitterStrategyTest {
 
     @Test
     public void testIsAutomaticBuildValidIgnoredAuthors() throws Throwable {
-        strategy = new IgnoreCommitterStrategy("gits@mpleRepoRule,ignore@example.com", true); // Author from sampleRepoRule
+        strategy = new IgnoreCommitterStrategy("gits@mpleRepoRule,ignore@example.com", true);
         assertFalse(strategy.isAutomaticBuild(source, head, currRevision, prevRevision, lastSeenRevision, listener));
     }
 
     @Test
     public void testIsAutomaticBuildValidIgnoredAuthorsNoBuildIfExcluded() throws Throwable {
-        strategy = new IgnoreCommitterStrategy("ignore@example.com,gits@mpleRepoRule", false); // Author from sampleRepoRule
+        strategy = new IgnoreCommitterStrategy("ignore@example.com,gits@mpleRepoRule", false);
         assertFalse(strategy.isAutomaticBuild(source, head, currRevision, prevRevision, lastSeenRevision, listener));
+    }
+
+    @Test
+    public void testIsAutomaticBuildValidIgnoredAuthorNullRevision() throws Throwable {
+        strategy = new IgnoreCommitterStrategy("gits@mpleRepoRule,other@example.com", true);
+        assertFalse(strategy.isAutomaticBuild(source, head, currRevision, prevRevision, null, listener));
+    }
+
+    @Test
+    public void testIsAutomaticBuildValidIgnoredAuthorsNullRevision() throws Throwable {
+        strategy = new IgnoreCommitterStrategy("gits@mpleRepoRule,ignore@example.com,other@example.com", true);
+        assertFalse(strategy.isAutomaticBuild(source, head, currRevision, null, lastSeenRevision, listener));
+    }
+
+    @Test
+    public void testIsAutomaticBuildValidIgnoredAuthorsNullRevisions() throws Throwable {
+        strategy = new IgnoreCommitterStrategy("gits@mpleRepoRule,ignore@example.com,other@example.com", true);
+        assertFalse(strategy.isAutomaticBuild(source, head, currRevision, null, null, listener));
+    }
+
+    @Test
+    public void testIsAutomaticBuildValidIgnoredAuthorsNoBuildIfExcludedNullRevision() throws Throwable {
+        strategy = new IgnoreCommitterStrategy("ignore@example.com,gits@mpleRepoRule", false);
+        assertFalse(strategy.isAutomaticBuild(source, head, null, prevRevision, lastSeenRevision, listener));
     }
 
     private static abstract class FakeSCMSourceOwner implements SCMSourceOwner {


### PR DESCRIPTION
## Require Jenkins 2.452.4 or newer

Require Java 11, support Java 17 and Java 21

Use plugin BOM for versions of dependent plugins

Remove extraneous dependencies

Replace powermock tests with JenkinsRule tests

Includes pull requests:

* #5
* #7
* #3 

Removes the implied dependency on Oracle Java SE installer plugin and on any other plugins extracted from Jenkins core before 2.452.4.

### Testing done

Confirmed that automated tests pass.

Confirmed that the test coverage report increased from 4% coverage on the master branch to over 80% coverage on this pull request.

Configured a Bitbucket branch source job for my public repository and confirmed that when I exclude my email address, the commits are not built.  When I remove that exclusion, the commits are built.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
